### PR TITLE
add cc_info for registers using in calling convention

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -30,3 +30,7 @@ serde_derive = "*"
 
 [dependencies.r2pipe]
 git = "https://github.com/radare/r2pipe.rs"
+
+[[bin]]
+name = "api_example"
+path = "examples/api_example.rs"

--- a/rust/examples/api_example.rs
+++ b/rust/examples/api_example.rs
@@ -9,5 +9,5 @@ fn main() {
     let path = "/bin/ls";
     let mut r2 = R2::new(Some(path)).expect("Failed to spawn r2");
     r2.init();
-    println!("{:#?}", r2.fn_list().expect("Failed to get function list."));
+    println!("{:#?}", r2.cc_info().expect("Failed to get function list."));
 }

--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -56,6 +56,12 @@ impl R2Api for R2 {
         from_str(&raw_json)
     }
 
+    fn cc_info(&mut self) -> Result<LCCInfo, Error> {
+        self.send("afcrj");
+        let raw_json = self.recv();
+        from_str(&raw_json)
+    }
+
     fn locals_of(&mut self, location: u64) -> Result<Vec<LVarInfo>, Error> {
         self.send(&format!("afvbj @ {}", location));
         let x: Result<Vec<LVarInfo>, Error> = from_str(&self.recv());

--- a/rust/src/api_trait.rs
+++ b/rust/src/api_trait.rs
@@ -28,6 +28,9 @@ pub trait R2Api {
     /// Get list of functions
     fn fn_list(&mut self) -> Result<Vec<FunctionInfo>, Error>;
 
+    /// Get calling convention information for registers
+    fn cc_info(&mut self) -> Result<LCCInfo, Error>;
+
     /// Get list of sections
     fn sections(&mut self) -> Result<Vec<LSectionInfo>, Error>;
 

--- a/rust/src/structs.rs
+++ b/rust/src/structs.rs
@@ -127,3 +127,11 @@ pub struct LVarRef {
     pub base: Option<String>,
     pub offset: Option<i64>,
 }
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct LCCInfo {
+    pub ret: Option<String>,
+    pub args: Option<Vec<String>>,
+    #[serde(rename="float_args")]
+    pub fargs: Option<Vec<String>>,
+}


### PR DESCRIPTION
I have added a new command ["afcr"](https://github.com/radare/radare2/pull/8202) in r2, if the PR could be merged, this PR would help a lot for calling convention analysis