### PR TITLE
Change `cc_info` to be function-specific

### DIFF
--- a/rust/src/api.rs
+++ b/rust/src/api.rs
@@ -67,8 +67,8 @@ impl R2Api for R2 {
         from_str(&raw_json)
     }
 
-    fn cc_info(&mut self) -> Result<LCCInfo, Error> {
-        self.send("afcrj");
+    fn cc_info_of(&mut self, location: u64) -> Result<LCCInfo, Error> {
+        self.send(&format!("afcrj @ {}", location));
         let raw_json = self.recv();
         from_str(&raw_json)
     }

--- a/rust/src/api_trait.rs
+++ b/rust/src/api_trait.rs
@@ -21,8 +21,6 @@ pub trait R2Api {
     fn reg_info(&mut self) -> Result<LRegInfo, Error>;
     /// Get binary information
     fn bin_info(&mut self) -> Result<LBinInfo, Error>;
-    /// Get calling convention information for registers
-    fn cc_info(&mut self) -> Result<LCCInfo, Error>;
 
 
     //////////////////////////////////////////////
@@ -79,6 +77,8 @@ pub trait R2Api {
     fn strings(&mut self, bool) -> Result<Vec<LStringInfo>, Error>;
     /// Get list of local variables in function defined at a particular address
     fn locals_of(&mut self, u64) -> Result<Vec<LVarInfo>, Error>;
+    /// Get calling convention information for a function defined at a particular address
+    fn cc_info_of(&mut self, location: u64) -> Result<LCCInfo, Error>;
     /// Detect a function at a particular address in the binary
     fn function<T: AsRef<str>>(&mut self, T) -> Result<LFunctionInfo, Error>;
 


### PR DESCRIPTION
`afcrj` gets the callconv _for the function at the current offset_, so it should be run at a offset inside a function.

AFAICT `cc_info` was never used anywhere, so this change shouldn't break anything.