### PR TITLE
Update Cargo.toml to avoid confusion 

### DIFF
--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -29,7 +29,7 @@ serde_json = "*"
 serde_derive = "*"
 
 [dependencies.r2pipe]
-git = "https://github.com/radare/r2pipe.rs"
+git = "https://github.com/radareorg/r2pipe.rs"
 
 [[bin]]
 name = "api_example"

--- a/rust/examples/api_example.rs
+++ b/rust/examples/api_example.rs
@@ -9,7 +9,10 @@ fn main() {
     let path = "/bin/ls";
     let mut r2 = R2::new(Some(path)).expect("Failed to spawn r2");
     r2.init();
-    println!("{:#?}", r2.cc_info().expect("Failed to get function list."));
+    r2.analyze();
+    println!("{:#?}", r2.reg_info());
+    println!("{:#?}", r2.bin_info());
+    println!("{:#?}", r2.flag_info());
     println!("{:#?}", r2.fn_list());
     println!("{:#?}", r2.symbols());
     println!("{:#?}", r2.imports());


### PR DESCRIPTION
Because all rust repo have moved to radareorg, the `Cargo.toml` needs to be updated to avoid confusion.