### PR TITLE
Add context manager for R2Api object

### DIFF
--- a/python/r2api/r2api.py
+++ b/python/r2api/r2api.py
@@ -83,6 +83,12 @@ class R2Api(R2Base):
         ]
         self.seek = lambda x: self._exec("s %s" % (x))
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, e_type, e_val, tb):
+        self.quit()
+
     def open(self, filename, at="", perms=""):
         # See o?
         self._exec("o %s %s %s" % (filename, at, perms))

--- a/python/test/test_r2api.py
+++ b/python/test/test_r2api.py
@@ -15,6 +15,11 @@ def test_quit():
     with pytest.raises(AttributeError):
         r._exec("px 1")
 
+def test_context():
+    with R2Api("test_bin") as r:
+        pass
+    with pytest.raises(AttributeError):
+        r._exec("px 1")
 
 def test_info():
     r = get_r2api()


### PR DESCRIPTION
As proposed in #14, now it's not necessary to do r.quit() at the end of your
script:

``` python
with R2Api('-') as r:
    r.print.hexdump(5)
```

First implementation, probably it can be improved.